### PR TITLE
Add diabetes page with SEO metadata

### DIFF
--- a/blogs/diabetes.html
+++ b/blogs/diabetes.html
@@ -1,0 +1,210 @@
+<!DOCTYPE HTML>
+<!-- AspartameAwareness.org
+    Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
+<html>
+    <head>
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>
+        <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-66V8PFSQ44');
+        </script>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet" href="../css/main.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">
+        <!-- Load favicons -->
+        <script>
+            fetch("/favicons.html")
+            .then(response => response.text())
+            .then(data => {
+                document.head.insertAdjacentHTML("beforeend", data);
+            });
+        </script>
+        <title>Aspartame and Diabetes: What You Should Know</title>
+        <meta name="description" content="Learn how aspartame affects blood sugar and insulin response. Discover research about artificial sweeteners and diabetes management.">
+        <meta name="keywords" content="aspartame and diabetes, blood sugar, insulin response, artificial sweeteners, diabetic diet">
+        <meta name="author" content="Adam Charles Johnston">
+        <!-- Open Graph meta tags for social media sharing -->
+        <meta property="og:title" content="Aspartame and Diabetes: What You Should Know">
+        <meta property="og:description" content="Understand the impact of aspartame on blood glucose and insulin. Helpful information for people managing diabetes.">
+        <meta property="og:image" content="https://aspartameawareness.org/images/blog/lg/cans-lg.jpg">
+        <meta property="og:url" content="https://aspartameawareness.org/blogs/diabetes">
+        <meta property="og:type" content="article">
+        <!-- Twitter Card meta tags -->
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:title" content="Aspartame and Diabetes: What You Should Know">
+        <meta name="twitter:description" content="Learn how aspartame influences blood sugar levels and insulin response in diabetes.">
+        <meta name="twitter:image" content="https://aspartameawareness.org/images/blog/lg/cans-lg.jpg">
+    </head>
+    <body class="single is-preload">
+        <!-- Wrapper -->
+        <div id="wrapper">
+            <!-- Header -->
+            <header id="header">
+                <h1 class="index"><a href="../index.html">Aspartame Awareness<span class="small-org">.org</span></a></h1>
+                <nav class="links">
+                    <ul>
+                        <li><a href="../index.html">Home</a></li>
+                        <li><a href="../list-risks.html">Risks</a></li>
+                        <li><a href="alternatives.html">Alternatives</a></li>
+                        <li><a href="../research.html">Research</a></li>
+                    </ul>
+                </nav>
+                <nav class="main">
+                    <ul>
+                        <li class="search">
+                            <a class="fa-search" href="#search">Search</a>
+                            <form id="search" method="get" action="#">
+                                <input type="text" name="query" placeholder="Search" />
+                            </form>
+                        </li>
+                        <li class="menu">
+                            <a class="fa-bars" href="#menu">Menu</a>
+                        </li>
+                    </ul>
+                </nav>
+            </header>
+            <!-- Hamburger/ Sidebar -->
+            <section id="menu">
+                <section>
+                    <form class="search">
+                        <input type="text" id="searchInput2" name="query" placeholder="Search..." />
+                        <div id="dropdown2" class="dropdown"></div>
+                    </form>
+                </section>
+                <section>
+                    <ul class="links" id="sidebar-list">
+                    </ul>
+                </section>
+                <section>
+                    <ul class="actions stacked">
+                        <li><a href="research.html" class="button large fit">Research</a></li>
+                    </ul>
+                </section>
+            </section><!-- /Hamburger -->
+            <!-- Main -->
+            <div id="main">
+                <!-- Blog Post -->
+                <article class="post">
+                    <header>
+                        <div class="title">
+                            <h2><a href="#">Aspartame and Diabetes: What You Should Know</a></h2>
+                            <p>Does this popular sweetener really help control blood sugar?</p>
+                        </div>
+                        <div class="meta">
+                            <time class="published" datetime="2025-06-01">June 1, 2025</time>
+                            <span class="author"><span class="name"><div class="random-name"></div></span><img src="../images/logos/logo-A2.png" alt="" /></span>
+                        </div>
+                    </header>
+                    <span class="image featured"><img src="../images/blog/lg/cans-lg.jpg" alt="Diet soda cans" /></span>
+                    <h3>Blood Sugar Basics</h3>
+                    <p>Aspartame contains no carbohydrates, so it does not raise blood glucose the way table sugar does. That is why many "diet" or "zero" products use it to provide sweetness without added sugars. For people with diabetes, avoiding large spikes in blood sugar is important, and aspartame can help reduce overall sugar intake.</p>
+                    <h3>Insulin Response</h3>
+                    <p>Some studies show that aspartame has little to no direct effect on insulin levels. However, individual responses can vary. Monitoring blood glucose after consuming foods with aspartame is the best way to see how your body reacts.</p>
+                    <h3>Is Aspartame Safe for Diabetics?</h3>
+                    <p>Health authorities like the <strong>FDA</strong> and <strong>EFSA</strong> consider aspartame safe within recommended limits. Most research indicates it does not negatively affect blood sugar control when used in moderation. Still, people who are sensitive to artificial sweeteners or who notice symptoms after consuming them should consult their healthcare provider.</p>
+                    <h3>Bottom Line</h3>
+                    <p>Aspartame can be a useful tool for reducing sugar in a diabetic diet, but it is not a cure-all. Balanced meals, regular monitoring, and guidance from healthcare professionals remain key for effective diabetes management.</p>
+                    <hr />
+                    <h3>References</h3>
+                    <ul class="dash" id="ref">
+                        <li>Food and Drug Administration. "Additional Information about High-Intensity Sweeteners." <a href="https://www.fda.gov/food/food-additives-petitions/additional-information-about-high-intensity-sweeteners-permitted-use-food-united-states" target="_blank">FDA Website</a></li>
+                        <li>European Food Safety Authority. "Scientific Opinion on the Re-evaluation of Aspartame." <a href="https://www.efsa.europa.eu/" target="_blank">EFSA</a></li>
+                        <li>American Diabetes Association. "Using Low-Calorie Sweeteners." <a href="https://diabetes.org" target="_blank">diabetes.org</a></li>
+                    </ul>
+                    <br>
+                    <section>
+                        <h5>please share:</h5>
+                        <div class="a2a_kit a2a_kit_size_32 a2a_default_style" data-a2a-icon-color="white,gray">
+                            <a class="a2a_button_copy_link"></a>
+                            <a class="a2a_button_x"></a>
+                            <a class="a2a_button_facebook"></a>
+                            <a class="a2a_button_reddit"></a>
+                            <a class="a2a_button_email"></a>
+                        </div>
+                    </section>
+                    <footer>
+                        <ul class="stats">
+                            <li><a href="#">Sweetener</a></li>
+                            <li><a href="#">Diabetes</a></li>
+                        </ul>
+                    </footer>
+                </article>
+            </div><!-- /main -->
+            <!-- Pagination -->
+            <ul class="actions pagination">
+                <li><a href="javascript:void(0);" onclick="window.history.back();" class="button large previous"><i class="fas fa-arrow-left"></i> Back</a></li>
+                <li><a href="../index.html" class="button large previous"><i class="fas fa-home"></i> Home</a></li>
+                <li><a href="#" class="button large next" id="next-page-button">Next <i class="fas fa-arrow-right"></i></a></li>
+            </ul><br>
+            <article class="post">
+                <h2>More posts:</h2>
+                <section id="mini-posts">
+                    <div class="mini-posts" id="mini-posts-container">
+                    </div>
+                </section>
+            </article>
+            <!-- Footer -->
+            <section id="footer">
+                <ul class="icons">
+                    <li><a href="https://x.com/aspartame_aware" class="fa-brands fa-x-twitter"><span class="label">x.com</span></a></li>
+                    <li><a href="https://www.facebook.com/profile.php?id=61568997801261" class="icon brands fa-facebook" target="_blank"><span class="label">Facebook</span></a></li>
+                    <li><a href="https://github.com/aspartame-aware" class="icon brands fa-github"><span class="label">Github</span></a></li>
+                    <li><a href="https://www.youtube.com/@aspartameawareness" class="icon brands fa-youtube" target="_blank"><span class="label">YouTube</span></a></li>
+                    <li><a href="mailto:info@aspartameawareness.org" class="icon solid fa-envelope"><span class="label">Email</span></a></li>
+                </ul>
+                <p class="copyright">Images: <a href="https://unsplash.com">Unsplash</a>, <a href="https://nightcafe.com">Nightcafe</a> &amp; <a href="https://pexels.com">Pexels</a>.
+                    <br>2017-2025 &copy; Aspartame Awareness. </p>
+            </section>
+            <!-- Sitemap Section -->
+            <section id="sitemap" class="footer-sitemap">
+                <div class="row">
+                    <div class="column">
+                        <h3>About</h3>
+                        <ul>
+                            <li><a href="../about.html#about">About Us</a></li>
+                            <li><a href="../about.html#mission">Our Mission</a></li>
+                            <li><a href="../privacy.html">Privacy Policy</a></li>
+                            <li><a href="../service.html">Terms of Service</a></li>
+                        </ul>
+                    </div>
+                    <div class="column">
+                        <h3>Resources</h3>
+                        <ul>
+                            <li><a href="../index.html#blog">Blog</a></li>
+                            <li><a href="../research.html">Research</a></li>
+                            <li><a href="../FAQ's.html">FAQs</a></li>
+                            <li><a href="../contact.html">Contact</a></li>
+                        </ul>
+                    </div>
+                    <div class="column">
+                        <h3>Community</h3>
+                        <ul>
+                            <li><a href="../get-involved.html">Get Involved</a></li>
+                            <li>Events</li>
+                            <li>Discussion</li>
+                            <li><a href="../support.html">Support Us</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+        </div><!-- /wrapper -->
+        <!-- Scripts -->
+        <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
+        <script src="../js/adsterra.js"></script>
+        <script defer src="https://static.addtoany.com/menu/page.js"></script>
+        <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+        <script src="../js/mini-posts.js"></script><!--small post cards-->
+        <script src="../js/random-author.js"></script><!--author name-->
+        <script src="../js/urls-blog.js"></script><!--next button-->
+        <script src="../js/jquery.min.js"></script>
+        <script src="../js/browser.min.js"></script>
+        <script src="../js/breakpoints.min.js"></script>
+        <script src="../js/util.js"></script>
+        <script src="../js/main.js"></script>
+    </body>
+</html>

--- a/json/posts-blog.json
+++ b/json/posts-blog.json
@@ -108,5 +108,15 @@
     "img_alt": "aspartame symptoms",
     "date_one": "2025-05-18",
     "date_two": "May 18, 2025"
+  },
+  {
+    "url": "diabetes.html",
+    "title": "Aspartame and Diabetes",
+    "sub": "How artificial sweeteners influence blood sugar and insulin response",
+    "img_url": "../images/blog/sm/cans-sm.jpg",
+    "img_url_md": "../images/blog/md/cans-md.jpg",
+    "img_alt": "diet soda cans",
+    "date_one": "2025-06-01",
+    "date_two": "June 01, 2025"
   }
 ]

--- a/json/posts.json
+++ b/json/posts.json
@@ -108,5 +108,15 @@
     "img_alt": "aspartame symptoms",
     "date_one": "2025-05-18",
     "date_two": "May 18, 2025"
+  },
+  {
+    "url": "blogs/diabetes.html",
+    "title": "Aspartame and Diabetes",
+    "sub": "How artificial sweeteners influence blood sugar and insulin response",
+    "img_url": "images/blog/sm/cans-sm.jpg",
+    "img_url-md": "images/blog/md/cans-md.jpg",
+    "img_alt": "diet soda cans",
+    "date_one": "2025-06-01",
+    "date_two": "June 01, 2025"
   }
 ]


### PR DESCRIPTION
## Summary
- create **diabetes.html** blog article detailing aspartame use for diabetics
- update `posts.json` and `posts-blog.json` so the new post appears on the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867327defec8329886b7ef81b3aa502