### PR TITLE
Add robots.txt and sitemap

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://aspartameawareness.org/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://aspartameawareness.org/404.html</loc></url>
+  <url><loc>https://aspartameawareness.org/FAQ's.html</loc></url>
+  <url><loc>https://aspartameawareness.org/about.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/adhd.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/alternatives.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/aspartame-side-effects.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/aspartame.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/ban.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/carcinogenic.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/detox.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/e951.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/methanol.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/phenylalanine.html</loc></url>
+  <url><loc>https://aspartameawareness.org/blogs/understanding.html</loc></url>
+  <url><loc>https://aspartameawareness.org/events.html</loc></url>
+  <url><loc>https://aspartameawareness.org/favicons.html</loc></url>
+  <url><loc>https://aspartameawareness.org/get-involved.html</loc></url>
+  <url><loc>https://aspartameawareness.org/</loc></url>
+  <url><loc>https://aspartameawareness.org/list-risks.html</loc></url>
+  <url><loc>https://aspartameawareness.org/privacy.html</loc></url>
+  <url><loc>https://aspartameawareness.org/research.html</loc></url>
+  <url><loc>https://aspartameawareness.org/service.html</loc></url>
+  <url><loc>https://aspartameawareness.org/support.html</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add a robots.txt that allows indexing and links to sitemap
- generate sitemap.xml for all public HTML pages

## Testing
- `cat robots.txt`
- `cat sitemap.xml`

------
https://chatgpt.com/codex/tasks/task_e_68672e9407588329a6b0c71b30bd5b13