### PR TITLE
Fix msapplication TileImage paths

### DIFF
--- a/FAQ's.html
+++ b/FAQ's.html
@@ -38,7 +38,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 	</head>
 	<body class="is-preload">

--- a/blogs/alternatives.html
+++ b/blogs/alternatives.html
@@ -38,7 +38,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/blogs/carcinogenic.html
+++ b/blogs/carcinogenic.html
@@ -38,7 +38,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 
         <meta name="description" content="A detailed exploration of aspartame's carcinogenic risks, with insights from IARC findings and recent studies.">

--- a/blogs/e951.html
+++ b/blogs/e951.html
@@ -38,7 +38,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 
 

--- a/favicons.html
+++ b/favicons.html
@@ -15,5 +15,5 @@
 <link rel="shortcut icon" href="images/favicon/favicon.ico" type="image/x-icon">
 <link rel="manifest" href="images/favicon/manifest.json">
 <meta name="msapplication-TileColor" content="#ffffff">
-<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 <meta name="theme-color" content="#ffffff">

--- a/get-involved.html
+++ b/get-involved.html
@@ -42,7 +42,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">

--- a/list-risks.html
+++ b/list-risks.html
@@ -38,7 +38,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="is-preload">

--- a/privacy.html
+++ b/privacy.html
@@ -42,7 +42,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">

--- a/private-dev/root/FAQ's.html
+++ b/private-dev/root/FAQ's.html
@@ -28,7 +28,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 	</head>
 	<body class="is-preload">

--- a/private-dev/root/blogs/adhd.html
+++ b/private-dev/root/blogs/adhd.html
@@ -28,7 +28,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 
 		<meta name="description" content="Explore the relationship between aspartame, phenylalanine, and ADHD in this detailed analysis. Learn about the studies that investigate the effects of artificial sweeteners on cognitive function and behavior.">

--- a/private-dev/root/blogs/alternatives.html
+++ b/private-dev/root/blogs/alternatives.html
@@ -28,7 +28,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/private-dev/root/blogs/aspartame.html
+++ b/private-dev/root/blogs/aspartame.html
@@ -28,7 +28,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
         <meta name="description" content="An in-depth look at aspartame, its role as an artificial sweetener, and the ongoing controversies surrounding its safety.">
         <meta name="keywords" content="aspartame, artificial sweetener, sugar substitute, health risks, benefits">

--- a/private-dev/root/blogs/carcinogenic.html
+++ b/private-dev/root/blogs/carcinogenic.html
@@ -28,7 +28,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 
         <meta name="description" content="A detailed exploration of aspartame's carcinogenic risks, with insights from IARC findings and recent studies.">

--- a/private-dev/root/blogs/detox.html
+++ b/private-dev/root/blogs/detox.html
@@ -28,7 +28,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 
     <meta name="description" content="Explore potential ways to mitigate the negative effects of aspartame, phenylalanine, and methanol. Discover detox methods and foods that help.">

--- a/private-dev/root/blogs/e951.html
+++ b/private-dev/root/blogs/e951.html
@@ -28,7 +28,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 
 

--- a/private-dev/root/blogs/methanol.html
+++ b/private-dev/root/blogs/methanol.html
@@ -28,7 +28,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 
 		<meta name="description" content="Explore the dangers of methanol and the sensitivities related to aspartame consumption. Learn about the implications for individuals with specific health conditions.">

--- a/private-dev/root/blogs/phenylalanine.html
+++ b/private-dev/root/blogs/phenylalanine.html
@@ -28,7 +28,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
         
         <meta name="description" content="An in-depth look at phenylalanine, its role in aspartame, and potential health risks associated with consumption, especially for those with PKU.">

--- a/private-dev/root/blogs/understanding.html
+++ b/private-dev/root/blogs/understanding.html
@@ -28,7 +28,7 @@
         <link rel="manifest" href="images/favicon/manifest.json">
 
         <meta name="msapplication-TileColor" content="#ffffff">
-        <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+        <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
         <meta name="theme-color" content="#ffffff">
         
         <meta name="description" content="A deep dive into aspartame, its daily intake, history, and its presence in popular foods and drinks.">

--- a/private-dev/root/get-involved.html
+++ b/private-dev/root/get-involved.html
@@ -32,7 +32,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">

--- a/private-dev/root/index.html
+++ b/private-dev/root/index.html
@@ -28,7 +28,7 @@
 		<link rel="manifest" href="images/favicon/manifest.json">
 
 		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
 		<meta name="theme-color" content="#ffffff">
 	</head>
 <body class="is-preload">

--- a/private-dev/root/list-risks.html
+++ b/private-dev/root/list-risks.html
@@ -28,7 +28,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="is-preload">

--- a/private-dev/root/privacy.html
+++ b/private-dev/root/privacy.html
@@ -32,7 +32,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">

--- a/private-dev/root/research.html
+++ b/private-dev/root/research.html
@@ -32,7 +32,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">

--- a/private-dev/root/service.html
+++ b/private-dev/root/service.html
@@ -32,7 +32,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">

--- a/private-dev/root/support.html
+++ b/private-dev/root/support.html
@@ -41,7 +41,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">

--- a/research.html
+++ b/research.html
@@ -42,7 +42,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">

--- a/service.html
+++ b/service.html
@@ -42,7 +42,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">

--- a/support.html
+++ b/support.html
@@ -42,7 +42,7 @@
     <link rel="manifest" href="images/favicon/manifest.json">
 
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="img/favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">


### PR DESCRIPTION
## Summary
- use new images/favicon path for `msapplication-TileImage` in all HTML files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68672eaf37bc8329b095e2af8e5d0f19