### PR TITLE
Add lang attribute to root HTML pages

### DIFF
--- a/FAQ's.html
+++ b/FAQ's.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- AspartameAwareness.org
     Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
-<html>
+<html lang="en">
 	<head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>

--- a/about.html
+++ b/about.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- AspartameAwareness.org
     Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
-<html>
+<html lang="en">
 	<head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>

--- a/get-involved.html
+++ b/get-involved.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- AspartameAwareness.org
     Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
-<html>
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- AspartameAwareness.org
     Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
-<html>
+<html lang="en">
 	<head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>

--- a/list-risks.html
+++ b/list-risks.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- AspartameAwareness.org
     Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
-<html>
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- AspartameAwareness.org
     Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
-<html>
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>

--- a/research.html
+++ b/research.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- AspartameAwareness.org
     Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
-<html>
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>

--- a/service.html
+++ b/service.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- AspartameAwareness.org
     Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
-<html>
+<html lang="en">
 <head>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>

--- a/support.html
+++ b/support.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- AspartameAwareness.org
     Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
-<html>
+<html lang="en">
 <head>
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>


### PR DESCRIPTION
## Summary
- specify `lang="en"` in HTML root tags for accessibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68672eb0c3ec8329a71c12c4a1b3f590