### PR TITLE
Add service worker for offline support

### DIFF
--- a/404.html
+++ b/404.html
@@ -97,5 +97,6 @@
     </p>
     <a href="/" class="btn">Return Before They Notice</a>
   </div>
+    <script src="js/sw-register.js"></script>
 </body>
 </html>

--- a/FAQ's.html
+++ b/FAQ's.html
@@ -234,5 +234,6 @@
 		<script src="js/util.js"></script>
 		<script src="js/main.js"></script>
 
+    <script src="js/sw-register.js"></script>
 	</body>
 </html>

--- a/about.html
+++ b/about.html
@@ -198,5 +198,6 @@
         <script src="js/util.js"></script>
         <script src="js/main.js"></script>
 
+    <script src="js/sw-register.js"></script>
 	</body>
 </html>

--- a/blogs/adhd.html
+++ b/blogs/adhd.html
@@ -260,5 +260,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/blogs/alternatives.html
+++ b/blogs/alternatives.html
@@ -265,5 +265,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/blogs/aspartame-side-effects.html
+++ b/blogs/aspartame-side-effects.html
@@ -264,5 +264,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/blogs/aspartame.html
+++ b/blogs/aspartame.html
@@ -256,5 +256,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/blogs/ban.html
+++ b/blogs/ban.html
@@ -222,5 +222,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/blogs/carcinogenic.html
+++ b/blogs/carcinogenic.html
@@ -261,5 +261,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/blogs/detox.html
+++ b/blogs/detox.html
@@ -254,5 +254,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/blogs/diabetes.html
+++ b/blogs/diabetes.html
@@ -206,5 +206,6 @@
         <script src="../js/breakpoints.min.js"></script>
         <script src="../js/util.js"></script>
         <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
     </body>
 </html>

--- a/blogs/e951.html
+++ b/blogs/e951.html
@@ -344,5 +344,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/blogs/methanol.html
+++ b/blogs/methanol.html
@@ -249,5 +249,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/blogs/phenylalanine.html
+++ b/blogs/phenylalanine.html
@@ -246,5 +246,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/blogs/understanding.html
+++ b/blogs/understanding.html
@@ -330,5 +330,6 @@
     <script src="../js/breakpoints.min.js"></script>
     <script src="../js/util.js"></script>
     <script src="../js/main.js"></script>
+    <script src="../js/sw-register.js"></script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -166,5 +166,6 @@
             <script src="js/breakpoints.min.js"></script>
             <script src="js/util.js"></script>
             <script src="js/main.js"></script>
+    <script src="js/sw-register.js"></script>
     </body>
 </html>

--- a/get-involved.html
+++ b/get-involved.html
@@ -229,5 +229,6 @@
     <script src="js/browser.min.js"></script>
     <script src="js/breakpoints.min.js"></script>
     <script src="js/util.js"></script>
+    <script src="js/sw-register.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -352,5 +352,6 @@
 	<script src="js/util.js"></script>
 	<script src="js/main.js"></script>
 
+    <script src="js/sw-register.js"></script>
 </body>
 </html>

--- a/js/sw-register.js
+++ b/js/sw-register.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js').catch(err => console.error('SW registration failed:', err));
+    });
+}

--- a/list-risks.html
+++ b/list-risks.html
@@ -200,5 +200,6 @@
 	<script src="js/breakpoints.min.js"></script>
 	<script src="js/util.js"></script>
 	<script src="js/main.js"></script>
+    <script src="js/sw-register.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -193,5 +193,6 @@
     <script src="js/browser.min.js"></script>
     <script src="js/breakpoints.min.js"></script>
     <script src="js/util.js"></script>
+    <script src="js/sw-register.js"></script>
 </body>
 </html>

--- a/research.html
+++ b/research.html
@@ -279,5 +279,6 @@
     <script src="js/browser.min.js"></script>
     <script src="js/breakpoints.min.js"></script>
     <script src="js/util.js"></script>
+    <script src="js/sw-register.js"></script>
 </body>
 </html>

--- a/service.html
+++ b/service.html
@@ -192,5 +192,6 @@
     <script src="js/browser.min.js"></script>
     <script src="js/breakpoints.min.js"></script>
     <script src="js/util.js"></script>
+    <script src="js/sw-register.js"></script>
 </body>
 </html>

--- a/support.html
+++ b/support.html
@@ -217,5 +217,6 @@
     <script src="js/browser.min.js"></script>
     <script src="js/breakpoints.min.js"></script>
     <script src="js/util.js"></script>
+    <script src="js/sw-register.js"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,58 @@
+const CACHE_NAME = 'aspartame-cache-v1';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/about.html',
+  '/events.html',
+  '/get-involved.html',
+  '/privacy.html',
+  '/support.html',
+  '/service.html',
+  '/list-risks.html',
+  '/research.html',
+  '/404.html',
+  '/FAQ\'s.html',
+  '/css/main.css',
+  '/js/main.js',
+  '/js/jquery.min.js',
+  '/js/browser.min.js',
+  '/js/breakpoints.min.js',
+  '/js/util.js',
+  '/js/sidebar-list.js',
+  '/js/mini-posts-home.js',
+  '/js/list-posts.js',
+  '/js/random-author.js',
+  '/js/search-box.js',
+  "/blogs/adhd.html",
+  "/blogs/alternatives.html",
+  "/blogs/aspartame-side-effects.html",
+  "/blogs/aspartame.html",
+  "/blogs/ban.html",
+  "/blogs/carcinogenic.html",
+  "/blogs/detox.html",
+  "/blogs/diabetes.html",
+  "/blogs/e951.html",
+  "/blogs/methanol.html",
+  "/blogs/phenylalanine.html",
+  "/blogs/understanding.html",
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(names => Promise.all(
+      names.filter(name => name !== CACHE_NAME).map(name => caches.delete(name))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- register a service worker on all pages
- implement `sw.js` to cache core assets and blog pages
- include `js/sw-register.js` with service worker registration logic

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686739fc1aac83299d8138b7b779dbab