### PR TITLE
Improve search dropdown UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To run this project locally:
     ```
 
 2. Open `index.html` in your web browser to view the site.
+3. Use the search box to explore blog posts; a friendly "No results found" message appears when no matches are found.
 
 ## Contributing
 

--- a/css/main.css
+++ b/css/main.css
@@ -3450,10 +3450,16 @@ nav.main {
 		}
 
 		/* Active state (when selected) */
-		.dropdown-item.active {
-			background-color: #D5BD23; /* Slightly different color for active state */
-			color: black; /* Text color for active item */
-		}
+.dropdown-item.active {
+                        background-color: #D5BD23; /* Slightly different color for active state */
+                        color: black; /* Text color for active item */
+                }
+
+                /* 'No results' message in dropdown */
+                .dropdown-no-results {
+                        color: #aaaaaa;
+                        cursor: default;
+                }
 
 
 			#header #search input {

--- a/js/search-box.js
+++ b/js/search-box.js
@@ -29,7 +29,11 @@ function handleSearch(inputId, dropdownId) {
                             dropdown.appendChild(item);
                         });
                     } else {
-                        dropdown.style.display = 'none';
+                        dropdown.style.display = 'block';
+                        var item = document.createElement('div');
+                        item.className = 'dropdown-item dropdown-no-results';
+                        item.textContent = 'No results found';
+                        dropdown.appendChild(item);
                     }
                 });
         } else {


### PR DESCRIPTION
## Summary
- show `No results found` in dropdown when search matches nothing
- style the no-results message
- document search hint in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68696a24161c8329b190c06819aa154c