### PR TITLE
Add offline fallback page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To run this project locally:
 
 2. Open `index.html` in your web browser to view the site.
 3. Use the search box to explore blog posts; a friendly "No results found" message appears when no matches are found.
+4. The service worker caches pages for offline use. When offline, you'll see a simple offline page with a link back home.
 
 ## Contributing
 

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Offline - Aspartame Awareness</title>
+    <link rel="stylesheet" href="css/main.css">
+    <style>
+        body {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            text-align: center;
+            background: #f8f8f8;
+        }
+        .offline-container {
+            max-width: 600px;
+            padding: 2rem;
+            border: 2px solid #000;
+            background: #fff;
+            box-shadow: 0 0 10px rgba(0,0,0,0.2);
+        }
+    </style>
+</head>
+<body>
+    <div class="offline-container">
+        <h1>You are offline</h1>
+        <p>Please check your internet connection. Cached pages can still be viewed.</p>
+        <a href="/" class="button">Back to Home</a>
+    </div>
+    <script src="js/sw-register.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -23,4 +23,5 @@
   <url><loc>https://aspartameawareness.org/research</loc></url>
   <url><loc>https://aspartameawareness.org/service</loc></url>
   <url><loc>https://aspartameawareness.org/support</loc></url>
+  <url><loc>https://aspartameawareness.org/offline</loc></url>
 </urlset>

--- a/sw.js
+++ b/sw.js
@@ -11,6 +11,7 @@ const urlsToCache = [
   '/list-risks',
   '/research',
   '/404',
+  '/offline',
   '/FAQ\'s',
   '/css/main.css',
   '/js/main.js',
@@ -53,6 +54,11 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    caches.match(event.request).then(response => {
+      return (
+        response ||
+        fetch(event.request).catch(() => caches.match('/offline'))
+      );
+    })
   );
 });


### PR DESCRIPTION
## Summary
- create `offline.html` for no-connection mode
- cache offline page in service worker and use it when fetch fails
- mention offline support in README
- include offline page in sitemap

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6869da630c948329b16b478f73c76507