### PR TITLE
Improve FAQ page SEO

### DIFF
--- a/FAQ's.html
+++ b/FAQ's.html
@@ -18,7 +18,11 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 		<link rel="stylesheet" href="css/main.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">
+                <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">
+
+                <meta name="description" content="Frequently asked questions about aspartame, its health risks, safety, and alternatives.">
+                <meta name="keywords" content="aspartame FAQ, aspartame safety, aspartame health risks, aspartame alternatives, Aspartame Awareness">
+                <link rel="canonical" href="https://aspartameawareness.org/FAQ's">
 
 		<link rel="apple-touch-icon" sizes="57x57" href="images/favicon/apple-icon-57x57.png">
 		<link rel="apple-touch-icon" sizes="60x60" href="images/favicon/apple-icon-60x60.png">
@@ -35,12 +39,60 @@
 		<link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
 		<link rel="icon" href="images/favicon/favicon.ico" type="image/x-icon">
 		<link rel="shortcut icon" href="images/favicon/favicon.ico" type="image/x-icon">
-		<link rel="manifest" href="images/favicon/manifest.json">
+                <link rel="manifest" href="images/favicon/manifest.json">
 
-		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
-		<meta name="theme-color" content="#ffffff">
-	</head>
+                <meta name="msapplication-TileColor" content="#ffffff">
+                <meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
+                <meta name="theme-color" content="#ffffff">
+                <script type="application/ld+json">
+                {
+                  "@context": "https://schema.org",
+                  "@type": "FAQPage",
+                  "mainEntity": [
+                    {
+                      "@type": "Question",
+                      "name": "What is Aspartame?",
+                      "acceptedAnswer": {
+                        "@type": "Answer",
+                        "text": "Aspartame is an artificial sweetener about 200 times sweeter than sugar, commonly used in diet products."
+                      }
+                    },
+                    {
+                      "@type": "Question",
+                      "name": "Is Aspartame Safe to Consume?",
+                      "acceptedAnswer": {
+                        "@type": "Answer",
+                        "text": "Health authorities consider aspartame safe within recommended limits, though individuals with PKU should avoid it."
+                      }
+                    },
+                    {
+                      "@type": "Question",
+                      "name": "Does Aspartame Cause Health Problems?",
+                      "acceptedAnswer": {
+                        "@type": "Answer",
+                        "text": "Most studies show no harm when consumed within recommended amounts, but some people report sensitivities such as headaches or dizziness."
+                      }
+                    },
+                    {
+                      "@type": "Question",
+                      "name": "Why Should I Be Concerned About Aspartame?",
+                      "acceptedAnswer": {
+                        "@type": "Answer",
+                        "text": "There is ongoing debate about potential links to neurological issues, cancer, and metabolic problems, so moderation is advised."
+                      }
+                    },
+                    {
+                      "@type": "Question",
+                      "name": "What Are Some Alternatives to Aspartame?",
+                      "acceptedAnswer": {
+                        "@type": "Answer",
+                        "text": "Popular alternatives include natural sweeteners like stevia, monk fruit, and erythritol."
+                      }
+                    }
+                  ]
+                }
+                </script>
+        </head>
 	<body class="is-preload">
 
 		<!-- Wrapper -->


### PR DESCRIPTION
## Summary
- add meta description, keywords, and canonical link to the FAQ page
- include FAQPage structured data with common questions about aspartame

## Testing
- `tidy -errors "FAQ's.html"`

------
https://chatgpt.com/codex/tasks/task_e_6869daaa72088329830f1e3bbe6b8215