### PR TITLE
Fix dark mode toggle placement and icon

### DIFF
--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -8,10 +8,18 @@ function initDarkMode() {
     const a = document.createElement('a');
     a.href = '#';
     a.id = 'darkModeToggle';
-    a.className = 'fa-solid fa-moon';
+    // Using Font Awesome 5 which doesn't recognize the `fa-solid` prefix
+    // Add only the icon class so it matches the other header icons
+    a.className = 'fa-moon';
     a.style.cursor = 'pointer';
     li.appendChild(a);
-    navList.appendChild(li);
+    // Insert toggle right after the search icon to keep it near related actions
+    const searchLi = navList.querySelector('li.search');
+    if (searchLi) {
+        navList.insertBefore(li, searchLi.nextSibling);
+    } else {
+        navList.appendChild(li);
+    }
 
     const stored = localStorage.getItem('darkMode') === 'true';
     if (stored) document.body.classList.add('dark-mode');


### PR DESCRIPTION
## Summary
- ensure dark mode toggle uses correct Font Awesome 5 classes
- insert toggle beside the search icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ace6dffa88329ac1c375673180e2d