### PR TITLE
Fix dark mode toggle initialization

### DIFF
--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -44,4 +44,12 @@ function initDarkMode() {
     }
 }
 
-document.addEventListener('DOMContentLoaded', initDarkMode);
+// Run immediately if the document has already loaded. When this script is
+// placed at the end of the page, the DOMContentLoaded event may have fired
+// before we register the listener which would prevent the toggle from being
+// added. This check ensures the toggle always appears.
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initDarkMode);
+} else {
+    initDarkMode();
+}


### PR DESCRIPTION
## Summary
- ensure dark mode toggle initializes even if DOMContentLoaded already fired

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b0dc2c0708329806cbe5e5b6f6052