### PR TITLE
Fix sitemap events link

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,7 +341,7 @@
 					<h3>Community</h3>
 					<ul>
 						<li><a href="get-involved">Get Involved</a></li>
-						<li>Events</li>
+                                                <li><a href="events">Events</a></li>
 						<li>Discussion</li>
 						<li><a href="support">Support Us</a></li>
 					</ul>


### PR DESCRIPTION
## Summary
- link to the events page from the sitemap section in `index.html`

## Testing
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686b2a3904c483299fbe7cf3eeceda25