### PR TITLE
Improve responsiveness of static pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -38,6 +38,12 @@
       box-shadow: 0 0 10px rgba(0,0,0,0.2);
       position: relative;
     }
+    @media (max-width: 480px) {
+      .container {
+        width: 90%;
+        margin: 1rem;
+      }
+    }
     h1 {
       font-size: 2.5rem;
       margin-bottom: 1rem;

--- a/about.html
+++ b/about.html
@@ -15,7 +15,7 @@
 	<script src="/js/adsterra.js"></script>
 		<title>About Us | Aspartame Awareness</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="stylesheet" href="css/main.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">

--- a/contact.html
+++ b/contact.html
@@ -15,7 +15,7 @@
 	<script src="/js/adsterra.js"></script>
 		<title>Contact Us | Aspartame Awareness</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="stylesheet" href="css/main.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">

--- a/events.html
+++ b/events.html
@@ -15,7 +15,7 @@
         <script src="/js/adsterra.js"></script>
         <title>Events | Aspartame Awareness</title>
         <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="css/main.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">

--- a/faqs.html
+++ b/faqs.html
@@ -15,7 +15,7 @@
 	<script src="/js/adsterra.js"></script>
 		<title>FAQ | Aspartame Awareness</title>
 		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="stylesheet" href="css/main.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
                 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">

--- a/favicons.html
+++ b/favicons.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Favicons</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="apple-touch-icon" sizes="57x57" href="images/favicon/apple-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="60x60" href="images/favicon/apple-icon-60x60.png">
 <link rel="apple-touch-icon" sizes="72x72" href="images/favicon/apple-icon-72x72.png">

--- a/list-risks.html
+++ b/list-risks.html
@@ -15,7 +15,7 @@
     <script src="/js/adsterra.js"></script>
     <title>Health Risks associated with Aspartame, phenylalanine & Methanol</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Detailed overview of health risks associated with aspartame, phenylalanine, and methanol.">
     <meta name="keywords" content="aspartame risks, phenylalanine dangers, methanol toxicity, aspartame side effects">
     <link rel="canonical" href="https://aspartameawareness.org/list-risks">

--- a/offline.html
+++ b/offline.html
@@ -24,6 +24,12 @@
             background: #fff;
             box-shadow: 0 0 10px rgba(0,0,0,0.2);
         }
+        @media (max-width: 480px) {
+            .offline-container {
+                width: 90%;
+                margin: 1rem;
+            }
+        }
     </style>
 </head>
 <body>

--- a/template/elements.html
+++ b/template/elements.html
@@ -6,7 +6,7 @@
 	<head>
 		<title>Future Imperfect by HTML5 UP</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="stylesheet" href="../css/main.css" />
 	</head>
 	<body class="is-preload">

--- a/template/single.html
+++ b/template/single.html
@@ -6,7 +6,7 @@
 	<head>
 		<title>Single - Future Imperfect by HTML5 UP</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="stylesheet" href="css/main.css" />
 	</head>
 	<body class="single is-preload">


### PR DESCRIPTION
## Summary
- allow zoom on mobile by removing `user-scalable=no`
- add viewport tag to `favicons.html`
- tweak offline and 404 pages for smaller screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b34074a4883299cc047df4e40fef8