### PR TITLE
Fix nav overlap on small screens

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -3491,22 +3491,30 @@ nav.main {
 
 		}
 
-		@media screen and (max-width: 736px) {
+                @media screen and (max-width: 736px) {
 
-			#header {
-				height: 2.75em;
-				line-height: 2.75em;
-			}
+                        #header {
+                                height: 2.75em;
+                                line-height: 2.75em;
+                        }
 
-				#header h1 {
-					padding: 0 0 0 1em;
-				}
+                                #header h1 {
+                                        padding: 0 0 0 1em;
+                                }
 
-				#header .main .search {
-					display: none;
-				}
+                                #header .main .search {
+                                        display: none;
+                                }
 
-		}
+                }
+
+                @media screen and (max-width: 480px) {
+
+                        #header #darkModeToggle {
+                                display: none;
+                        }
+
+                }
 
 /* Wrapper */
 


### PR DESCRIPTION
## Summary
- hide dark mode toggle on very small screens to keep the hamburger menu in the header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c1857ebb48329979c95df04979e3b