### PR TITLE
Improve dark mode handling

### DIFF
--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -21,9 +21,24 @@ function initDarkMode() {
         navList.appendChild(li);
     }
 
-    const stored = localStorage.getItem('darkMode') === 'true';
-    if (stored) document.body.classList.add('dark-mode');
+    const storedPref = localStorage.getItem('darkMode');
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    if (storedPref === 'true' || (storedPref === null && mediaQuery.matches)) {
+        document.body.classList.add('dark-mode');
+    }
     updateIcon();
+
+    // Update when user changes system preference and no explicit preference saved
+    mediaQuery.addEventListener('change', (e) => {
+        if (localStorage.getItem('darkMode') !== null) return;
+        if (e.matches) {
+            document.body.classList.add('dark-mode');
+        } else {
+            document.body.classList.remove('dark-mode');
+        }
+        updateIcon();
+    });
 
     a.addEventListener('click', function(e) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- update the dark-mode script to respect system preferences

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b24350a7c8329b4ae10a9b00ca080