### PR TITLE
Improve SEO with aspartame nav link

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <meta name="keywords" content="Aspartame, E951, health risks, artificial sweeteners, Aspartame Awareness, sugar substitutes, aspartame alternatives">
     <meta name="author" content="Adam Johnston">
     <link rel="canonical" href="https://aspartameawareness.org/">
+    <meta name="robots" content="index, follow">
     <meta property="og:title" content="Aspartame Awareness">
     <meta property="og:description" content="Research-based insights on aspartame's potential health risks and alternatives.">
     <meta property="og:image" content="https://aspartameawareness.org/images/logos/logo-A2.png">
@@ -50,13 +51,14 @@
 		<header id="header">
 			<h1><a href="/">Aspartame Awareness<span class="small-org">.org</span></a></h1>
 			<nav class="links">
-				<ul>
-					<li><a href="/">Home</a></li>
-					<li><a href="list-risks">Risks</a></li>
-					<li><a href="blogs/alternatives">Alternatives</a></li>
-					<li><a href="research">Research</a></li>
-				</ul>
-			</nav>
+                                <ul>
+                                        <li><a href="/">Home</a></li>
+                                        <li><a href="blogs/aspartame.html">Aspartame</a></li>
+                                        <li><a href="list-risks">Risks</a></li>
+                                        <li><a href="blogs/alternatives">Alternatives</a></li>
+                                        <li><a href="research">Research</a></li>
+                                </ul>
+                        </nav>
 			<nav class="main">
 				<ul>
 					<li class="search">
@@ -186,7 +188,7 @@
                                                         <span class="author"><span class="name"><span class="random-name"></span></span><img src="images/logos/logo-A2.png" alt="awareness avatar"></span>
 						</div>
 					</header>
-                                    <a href="blogs/aspartame.html" class="image featured"><img src="images/blog/lg/tub-lg.jpg" alt="apartame chemical compound"></a>
+                                    <a href="blogs/aspartame.html" class="image featured"><img src="images/blog/lg/tub-lg.jpg" alt="aspartame chemical compound"></a>
 					<p>Aspartame is one of the most commonly used artificial sweeteners, found in countless low-calorie and sugar-free products. With sweetness roughly 200 times that of sugar, aspartame offers an appealing way to add sweetness without the calories. But what exactly is aspartame, and why is there so much controversy surrounding its use? In this blog post, we'll dive into its components, uses, and the ongoing health debate...</p>
 					<footer>
 						<ul class="actions">

--- a/js/sidebar-list-blog.js
+++ b/js/sidebar-list-blog.js
@@ -21,6 +21,7 @@ function loadPostsList() {
             // Add basic navigation links for mobile menu
             const navLinks = [
                 { url: 'index', text: 'Home' },
+                { url: 'blogs/aspartame', text: 'Aspartame' },
                 { url: 'list-risks', text: 'Risks' },
                 { url: 'blogs/alternatives', text: 'Alternatives' },
                 { url: 'research', text: 'Research' }

--- a/js/sidebar-list.js
+++ b/js/sidebar-list.js
@@ -21,6 +21,7 @@ function loadPostsList() {
             // Add basic navigation links for mobile menu
             const navLinks = [
                 { url: 'index', text: 'Home' },
+                { url: 'blogs/aspartame', text: 'Aspartame' },
                 { url: 'list-risks', text: 'Risks' },
                 { url: 'blogs/alternatives', text: 'Alternatives' },
                 { url: 'research', text: 'Research' }


### PR DESCRIPTION
## Summary
- add 'Aspartame' link to main navigation
- fix misspelled alt text for the aspartame image
- add robots meta tag for indexing
- update sidebar navigation scripts to include the aspartame page

## Testing
- `tidy` *(fails: command not found)*
- `htmlhint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b24452d348329ae45705f0e9cb463