### PR TITLE
Enhance dark mode functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To run this project locally:
 2. Open `index.html` in your web browser to view the site.
 3. Use the search box to explore blog posts; a friendly "No results found" message appears when no matches are found.
 4. The service worker caches pages for offline use. When offline, you'll see a simple offline page with a link back home.
+5. Dark mode is available and now automatically follows your system preference on the first visit.
 
 ## Contributing
 

--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -21,8 +21,23 @@ function initDarkMode() {
         navList.appendChild(li);
     }
 
-    const stored = localStorage.getItem('darkMode') === 'true';
-    if (stored) document.body.classList.add('dark-mode');
+    // Determine desired mode. If the user has previously selected a mode we
+    // honour that choice. Otherwise default to the system preference using
+    // `prefers-color-scheme`.
+    const storedValue = localStorage.getItem('darkMode');
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const prefersDark = mql.matches;
+    const enabled = storedValue === null ? prefersDark : storedValue === 'true';
+
+    if (enabled) document.body.classList.add('dark-mode');
+
+    // When no explicit preference is stored, keep in sync with system changes
+    if (storedValue === null) {
+        mql.addEventListener('change', e => {
+            document.body.classList.toggle('dark-mode', e.matches);
+            updateIcon();
+        });
+    }
     updateIcon();
 
     a.addEventListener('click', function(e) {

--- a/sw.js
+++ b/sw.js
@@ -23,6 +23,7 @@ const urlsToCache = [
   '/js/mini-posts-home.js',
   '/js/list-posts.js',
   '/js/random-author.js',
+  '/js/dark-mode.js',
   '/js/search-box.js',
   "/blogs/adhd",
   "/blogs/alternatives",


### PR DESCRIPTION
## Summary
- sync default dark mode with system preference
- adjust dark mode when system theme changes
- mention automatic dark mode in README
- cache the new script in the service worker

## Testing
- `npx jshint js/dark-mode.js` *(fails: Need to install jshint)*

------
https://chatgpt.com/codex/tasks/task_e_686c3707ec408329a8a6556da4f8e3f4