### PR TITLE
Improve dark mode contrast

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -4038,27 +4038,30 @@ nav.main {
 
 /* Dark mode styles */
 body.dark-mode {
-    background: #1c1c1c;
-    color: #e0e0e0;
+    background: #181818;
+    color: #f4f4f4;
+    color-scheme: dark;
+    text-rendering: optimizeLegibility;
 }
 body.dark-mode a {
-    color: #9dc9f5;
+    color: #8cb8ff;
 }
 body.dark-mode #header,
 body.dark-mode #sidebar,
 body.dark-mode #menu,
 body.dark-mode #footer,
 body.dark-mode .post {
-    background: #2b2b2b;
+    background: #232323;
 }
 body.dark-mode input,
 body.dark-mode textarea,
 body.dark-mode select {
-    background: #333;
-    color: #e0e0e0;
+    background: #2a2a2a;
+    color: #f4f4f4;
+    border-color: #444;
 }
 body.dark-mode .button {
-    background: #444;
+    background: #4a4a4a;
     color: #fff;
 }
 /* Cookie Consent Banner */


### PR DESCRIPTION
## Summary
- tune dark-mode palette for better legibility

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c702c8e8c8329990e20f131ce3655