### PR TITLE
Improve dark mode toggle and styling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -4073,6 +4073,11 @@ body.dark-mode .button {
     background: #4a4a4a;
     color: #fff;
 }
+body.dark-mode code,
+body.dark-mode pre code {
+    background: #2a2a2a;
+    border-color: #444;
+}
 /* Cookie Consent Banner */
 #cookie-banner {
     position: fixed;

--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -12,6 +12,8 @@ function initDarkMode() {
     // glyph is rendered consistently across pages
     a.className = 'icon solid fa-moon';
     a.style.cursor = 'pointer';
+    a.setAttribute('aria-label', 'Switch to dark mode');
+    a.setAttribute('title', 'Switch to dark mode');
     li.appendChild(a);
     // Insert toggle right after the search icon to keep it near related actions
     const searchLi = navList.querySelector('li.search');
@@ -48,13 +50,21 @@ function initDarkMode() {
         updateIcon();
     });
 
+    const themeMeta = document.querySelector('meta[name="theme-color"]');
+
     function updateIcon() {
         if (document.body.classList.contains('dark-mode')) {
             a.classList.remove('fa-moon');
             a.classList.add('fa-sun');
+            a.setAttribute('aria-label', 'Switch to light mode');
+            a.setAttribute('title', 'Switch to light mode');
+            if (themeMeta) themeMeta.setAttribute('content', '#181818');
         } else {
             a.classList.remove('fa-sun');
             a.classList.add('fa-moon');
+            a.setAttribute('aria-label', 'Switch to dark mode');
+            a.setAttribute('title', 'Switch to dark mode');
+            if (themeMeta) themeMeta.setAttribute('content', '#ffffff');
         }
     }
 }


### PR DESCRIPTION
## Summary
- enhance dark mode toggle with accessible labeling
- update theme-color meta as dark mode switches
- tweak code block colors for dark mode

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686c76b16f3883298daea24738623609