### PR TITLE
Enhance dark mode styles

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -4055,6 +4055,9 @@ body.dark-mode {
 body.dark-mode a {
     color: #8cb8ff;
 }
+body.dark-mode a:hover {
+    color: #b5d4ff;
+}
 body.dark-mode #header,
 body.dark-mode #sidebar,
 body.dark-mode #menu,
@@ -4069,6 +4072,20 @@ body.dark-mode select {
     color: #f4f4f4;
     border-color: #444;
 }
+body.dark-mode ::-webkit-input-placeholder {
+    color: #bbbbbb;
+}
+body.dark-mode :-moz-placeholder {
+    color: #bbbbbb;
+    opacity: 1;
+}
+body.dark-mode ::-moz-placeholder {
+    color: #bbbbbb;
+    opacity: 1;
+}
+body.dark-mode :-ms-input-placeholder {
+    color: #bbbbbb;
+}
 body.dark-mode .button {
     background: #4a4a4a;
     color: #fff;
@@ -4077,6 +4094,9 @@ body.dark-mode code,
 body.dark-mode pre code {
     background: #2a2a2a;
     border-color: #444;
+}
+body.dark-mode #cookie-banner {
+    background: #1e1e1e;
 }
 /* Cookie Consent Banner */
 #cookie-banner {

--- a/index.html
+++ b/index.html
@@ -14,9 +14,10 @@
     </script>
 	<script src="/js/adsterra.js"></script>
                 <title>Aspartame Awareness | Health Risks, Research, and Alternatives</title>
-		<meta charset="utf-8">
+                <meta charset="utf-8">
                 <meta name="viewport" content="width=device-width, initial-scale=1">
-		<link rel="stylesheet" href="css/main.css">
+                <meta name="theme-color" content="#ffffff">
+                <link rel="stylesheet" href="css/main.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">
     <meta name="description" content="Aspartame Awareness provides research-based insights on the potential health risks of aspartame (E951) and offers safer sweetener alternatives.">


### PR DESCRIPTION
## Summary
- tweak dark mode CSS for links and form placeholders
- ensure cookie banner blends with dark mode
- add `theme-color` meta tag on the homepage

## Testing
- `node --version`
- `ls -R | grep -i test`

------
https://chatgpt.com/codex/tasks/task_e_686c789d41a88329a3943283318451db