### PR TITLE
Improve dark mode init

### DIFF
--- a/404.html
+++ b/404.html
@@ -85,6 +85,7 @@
   </style>
 </head>
 <body>
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
   <div class="container">
     <div class="stamp">CONFIDENTIAL</div>
     <h1>⚠️ Page Redacted</h1>

--- a/about.html
+++ b/about.html
@@ -44,6 +44,7 @@
         <!-- Additional Meta Tags for Structured Data -->
 	</head>
 	<body class="is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
 
 		<!-- Wrapper -->
 			<div id="wrapper">

--- a/contact.html
+++ b/contact.html
@@ -43,6 +43,7 @@
         <!-- Additional Meta Tags for Structured Data -->
 	</head>
 	<body class="is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
 
 		<!-- Wrapper -->
 			<div id="wrapper">

--- a/events.html
+++ b/events.html
@@ -44,6 +44,7 @@
         <!-- Additional Meta Tags for Structured Data -->
     </head>
     <body class="is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
 
             <!-- Wrapper -->
             <div id="wrapper">

--- a/faqs.html
+++ b/faqs.html
@@ -94,6 +94,7 @@
                 </script>
         </head>
 	<body class="is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
 
 		<!-- Wrapper -->
 			<div id="wrapper">

--- a/get-involved.html
+++ b/get-involved.html
@@ -47,6 +47,7 @@
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
     <!-- Wrapper -->
     <div id="wrapper">
         <!-- Header -->

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
 		
 	</head>
         <body class="is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
         <a class="skip-link" href="#main">Skip to main content</a>
         <!-- Wrapper -->
 	<div id="wrapper">

--- a/list-risks.html
+++ b/list-risks.html
@@ -45,6 +45,7 @@
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
     <!-- Wrapper -->
     <div id="wrapper">
         <!-- Header -->

--- a/offline.html
+++ b/offline.html
@@ -27,6 +27,7 @@
     </style>
 </head>
 <body>
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
     <div class="offline-container">
         <h1>You are offline</h1>
         <p>Please check your internet connection. Cached pages can still be viewed.</p>

--- a/privacy.html
+++ b/privacy.html
@@ -47,6 +47,7 @@
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
     <!-- Wrapper -->
     <div id="wrapper">
         <!-- Header -->

--- a/research.html
+++ b/research.html
@@ -47,6 +47,7 @@
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
     <!-- Wrapper -->
     <div id="wrapper">
         <!-- Header -->

--- a/service.html
+++ b/service.html
@@ -47,6 +47,7 @@
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
     <!-- Wrapper -->
     <div id="wrapper">
         <!-- Header -->

--- a/support.html
+++ b/support.html
@@ -47,6 +47,7 @@
     <meta name="theme-color" content="#ffffff">
 </head>
 <body class="single is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
     <!-- Wrapper -->
     <div id="wrapper">
         <!-- Header -->


### PR DESCRIPTION
## Summary
- inject early dark mode initialization script in all pages to respect prior
  preference and system theme

## Testing
- `npm test` *(fails: could not find package.json)*
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686c7a34729c8329af78e8c6ddedcfa6