### PR TITLE
Improve dark mode visuals

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -3590,17 +3590,17 @@ nav.main {
 		width: 22em;
 	}
 
-		#sidebar > * {
-			border-top: solid 1px rgba(160, 160, 160, 0.3);
-			margin: 3em 0 0 0;
-			padding: 3em 0 0 0;
-		}
+                #sidebar > * {
+                        border-top: solid 1px rgba(160, 160, 160, 0.3);
+                        margin: 3em 0 0 0;
+                        padding: 3em 3em 0 3em;
+                }
 
-		#sidebar > :first-child {
-			border-top: 0;
-			margin-top: 0;
-			padding-top: 0;
-		}
+                #sidebar > :first-child {
+                        border-top: 0;
+                        margin-top: 0;
+                        padding: 0 3em 0 3em;
+                }
 
 		@media screen and (max-width: 1280px) {
 
@@ -4097,6 +4097,26 @@ body.dark-mode pre code {
 }
 body.dark-mode #cookie-banner {
     background: #1e1e1e;
+}
+
+/* Dark mode adjustments */
+body.dark-mode h1,
+body.dark-mode h2,
+body.dark-mode h3,
+body.dark-mode h4,
+body.dark-mode h5,
+body.dark-mode h6 {
+    color: #e0e0e0;
+}
+
+body.dark-mode .footer-sitemap {
+    background-color: #232323;
+}
+
+body.dark-mode .footer-sitemap h3,
+body.dark-mode .footer-sitemap li,
+body.dark-mode .footer-sitemap a {
+    color: #f4f4f4;
 }
 /* Cookie Consent Banner */
 #cookie-banner {


### PR DESCRIPTION
## Summary
- add horizontal padding to sidebar sections
- style sitemap and header colors for dark mode

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d1708b7a48329adfd838dd8acea2a