### PR TITLE
Fix dark mode icon for Font Awesome 6

### DIFF
--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -8,12 +8,23 @@ function initDarkMode() {
     const a = document.createElement('a');
     a.href = '#';
     a.id = 'darkModeToggle';
-    // Use the same "icon" pattern as other header links so the Font Awesome
-    // glyph is rendered consistently across pages
-    a.className = 'icon solid fa-moon';
+    // Insert an <i> element so Font Awesome 6 icons work regardless of the
+    // theme's legacy "icon" styles.
+    const icon = document.createElement('i');
+    icon.className = 'fa-solid fa-moon';
+    icon.setAttribute('aria-hidden', 'true');
+
+    // Fallback text shown if the Font Awesome font fails to load
+    const fallback = document.createElement('span');
+    fallback.textContent = '🌓';
+    fallback.style.display = 'none';
+
+    a.className = 'icon';
     a.style.cursor = 'pointer';
     a.setAttribute('aria-label', 'Switch to dark mode');
     a.setAttribute('title', 'Switch to dark mode');
+    a.appendChild(icon);
+    a.appendChild(fallback);
     li.appendChild(a);
     // Insert toggle right after the search icon to keep it near related actions
     const searchLi = navList.querySelector('li.search');
@@ -54,18 +65,30 @@ function initDarkMode() {
 
     function updateIcon() {
         if (document.body.classList.contains('dark-mode')) {
-            a.classList.remove('fa-moon');
-            a.classList.add('fa-sun');
+            icon.classList.remove('fa-moon');
+            icon.classList.add('fa-sun');
             a.setAttribute('aria-label', 'Switch to light mode');
             a.setAttribute('title', 'Switch to light mode');
             if (themeMeta) themeMeta.setAttribute('content', '#181818');
         } else {
-            a.classList.remove('fa-sun');
-            a.classList.add('fa-moon');
+            icon.classList.remove('fa-sun');
+            icon.classList.add('fa-moon');
             a.setAttribute('aria-label', 'Switch to dark mode');
             a.setAttribute('title', 'Switch to dark mode');
             if (themeMeta) themeMeta.setAttribute('content', '#ffffff');
         }
+    }
+
+    // Display fallback text if the icon fails to load
+    if (document.fonts && document.fonts.ready) {
+        document.fonts.ready.then(() => {
+            if (icon.offsetWidth === 0) fallback.style.display = 'inline';
+        });
+    } else {
+        // Best-effort fallback for browsers without Font Loading API
+        setTimeout(() => {
+            if (icon.offsetWidth === 0) fallback.style.display = 'inline';
+        }, 500);
     }
 }
 


### PR DESCRIPTION
## Summary
- update dark-mode.js to use `<i>` element with Font Awesome 6 classes
- swap icon classes when toggling themes
- show emoji fallback if Font Awesome fails to load

## Testing
- `node --check js/dark-mode.js`

------
https://chatgpt.com/codex/tasks/task_e_686db56418b08329b839bdc83a2522eb