### PR TITLE
Fix dark mode link hover color

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -4056,7 +4056,7 @@ body.dark-mode a {
     color: #8cb8ff;
 }
 body.dark-mode a:hover {
-    color: #b5d4ff;
+    color: #b5d4ff !important;
 }
 body.dark-mode #header,
 body.dark-mode #sidebar,


### PR DESCRIPTION
## Summary
- fix red hover color overriding dark mode links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d81a6a5c083299894bc9077e0b123