### PR TITLE
Update sidebar and intro styles

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -3623,6 +3623,10 @@ nav.main {
 		
 /* Intro */
 
+#intro {
+       text-align: center;
+}
+
        #intro .logo {
                border-bottom: 0;
                display: block;
@@ -3925,7 +3929,7 @@ nav.main {
 		/*sitemap*/
                .footer-sitemap {
                        background-color: #f4f4f4; /* Match with your footer background */
-                       padding: 20px 0 0; /* Space around the sitemap */
+                       padding: 0; /* Align with footer without extra gap */
                        text-align: center; /* Center text */
                        width: 100%;
                        clear: both;
@@ -4061,6 +4065,7 @@ body.dark-mode a:hover {
 }
 body.dark-mode #header,
 body.dark-mode #sidebar,
+body.dark-mode #sidebar > *,
 body.dark-mode #menu,
 body.dark-mode #footer,
 body.dark-mode .post {
@@ -4115,6 +4120,7 @@ body.dark-mode h6 {
 
 body.dark-mode .footer-sitemap {
     background-color: #232323;
+    padding: 0;
 }
 
 body.dark-mode .footer-sitemap h3,

--- a/sass/layout/_intro.scss
+++ b/sass/layout/_intro.scss
@@ -6,14 +6,15 @@
 
 /* Intro */
 
-	#intro {
-		.logo {
-			border-bottom: 0;
-			display: inline-block;
-			margin: 0 0 (_size(element-margin) * 0.5) 0;
-			overflow: hidden;
-			position: relative;
-			width: 4em;
+       #intro {
+               text-align: center;
+               .logo {
+                       border-bottom: 0;
+                       display: block;
+                       margin: 0 auto (_size(element-margin) * 0.5);
+                       overflow: hidden;
+                       position: relative;
+                       width: 4em;
 
 			&:before {
 				background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="100px" height="100px" viewBox="0 0 100 100" preserveAspectRatio="none" zoomAndPan="disable"><polygon points="0,0 100,0 100,25 50,0 0,25" style="fill:#{_palette(bg-alt)}" /><polygon points="0,100 100,100 100,75 50,100 0,75"  style="fill:#{_palette(bg-alt)}" /></svg>');
@@ -29,12 +30,12 @@
 				width: 100%;
 			}
 
-			img {
-				display: block;
-				margin-left: -0.25em;
-				width: 4.5em;
-			}
-		}
+                       img {
+                               display: block;
+                               margin: 0 auto;
+                               width: 4.5em;
+                       }
+               }
 
 		header {
 			h2 {

--- a/sass/layout/_sidebar.scss
+++ b/sass/layout/_sidebar.scss
@@ -6,10 +6,11 @@
 
 /* Sidebar */
 
-	#sidebar {
-		margin-right: _size(section-spacing);
-		min-width: 22em;
-		width: 22em;
+       #sidebar {
+               margin-right: _size(section-spacing);
+               min-width: 22em;
+               width: 22em;
+               border: solid 1px _palette(border);
 
 		> * {
 			border-top: solid 1px _palette(border);
@@ -30,5 +31,4 @@
 			padding: _size(section-spacing) 0 0 0;
 			width: 100%;
 			overflow-x: hidden;
-		}
-	}
+		}	}


### PR DESCRIPTION
## Summary
- center the intro logo and update styling
- add border to sidebar for consistency
- keep mini-posts dark in dark mode
- align footer and sitemap backgrounds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e4bae144483298f01c0067c50ba38