### PR TITLE
Add quiz minigame

### DIFF
--- a/components/footer.html
+++ b/components/footer.html
@@ -28,8 +28,9 @@
 					<ul>
 						<li><a href="index#blog">Blog</a></li>
 						<li><a href="research">Research</a></li>
-						<li><a href="faqs">FAQs</a></li>
-						<li><a href="contact">Contact</a></li>
+                                                <li><a href="faqs">FAQs</a></li>
+                                                <li><a href="quiz">Quiz</a></li>
+                                                <li><a href="contact">Contact</a></li>
 					</ul>
 				</div>
 				<div class="column">

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
                                         <li><a href="list-risks">Risks</a></li>
                                         <li><a href="blogs/alternatives">Alternatives</a></li>
                                         <li><a href="research">Research</a></li>
+                                        <li><a href="quiz">Quiz</a></li>
                                 </ul>
                         </nav>
 			<nav class="main">

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1,0 +1,74 @@
+const quizData = [
+  {
+    question: 'What is aspartame primarily used as?',
+    options: ['Artificial sweetener', 'Natural sugar', 'Food coloring'],
+    answer: 0
+  },
+  {
+    question: 'Which code represents aspartame in food labeling?',
+    options: ['E100', 'E951', 'E621'],
+    answer: 1
+  },
+  {
+    question: 'Aspartame breaks down into which alcohol in the body?',
+    options: ['Ethanol', 'Methanol', 'Isopropanol'],
+    answer: 1
+  },
+  {
+    question: 'Which organization has evaluated aspartame for safety?',
+    options: ['World Health Organization', 'NASA', 'UNESCO'],
+    answer: 0
+  }
+];
+
+let currentQuestion = 0;
+let score = 0;
+
+function showQuestion() {
+  const container = document.getElementById('quiz-container');
+  if (!container) return;
+  container.innerHTML = '';
+
+  if (currentQuestion >= quizData.length) {
+    const result = document.getElementById('quiz-result');
+    result.style.display = 'block';
+    result.innerHTML = `<p>You scored ${score} out of ${quizData.length}.</p>` +
+      '<p><a href="support">Support our work</a> if you found this helpful!</p>';
+    return;
+  }
+
+  const q = quizData[currentQuestion];
+  const h3 = document.createElement('h3');
+  h3.textContent = q.question;
+  container.appendChild(h3);
+
+  q.options.forEach((opt, idx) => {
+    const label = document.createElement('label');
+    label.style.display = 'block';
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.name = 'option';
+    input.value = idx;
+    label.appendChild(input);
+    label.appendChild(document.createTextNode(' ' + opt));
+    container.appendChild(label);
+  });
+
+  const button = document.createElement('button');
+  button.textContent = 'Next';
+  button.onclick = checkAnswer;
+  container.appendChild(button);
+}
+
+function checkAnswer() {
+  const options = document.getElementsByName('option');
+  let selected = -1;
+  options.forEach(o => { if (o.checked) selected = parseInt(o.value); });
+  if (selected === quizData[currentQuestion].answer) {
+    score++;
+  }
+  currentQuestion++;
+  showQuestion();
+}
+
+document.addEventListener('DOMContentLoaded', showQuestion);

--- a/js/sidebar-list.js
+++ b/js/sidebar-list.js
@@ -25,7 +25,8 @@ function loadPostsList() {
 
                 { url: 'list-risks', text: 'Risks' },
                 { url: 'blogs/alternatives', text: 'Alternatives' },
-                { url: 'research', text: 'Research' }
+                { url: 'research', text: 'Research' },
+                { url: 'quiz', text: 'Quiz' }
             ];
 
             navLinks.forEach(item => {

--- a/quiz.html
+++ b/quiz.html
@@ -1,0 +1,85 @@
+<!DOCTYPE HTML>
+<!-- AspartameAwareness.org Quiz Page -->
+<html lang="en">
+<head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-66V8PFSQ44');
+    </script>
+    <script src="/js/adsterra.js"></script>
+    <title>Aspartame Awareness Quiz</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#ffffff">
+    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">
+    <meta name="description" content="Test your knowledge of aspartame with this quick quiz.">
+    <meta name="keywords" content="Aspartame quiz, E951 questions, artificial sweetener quiz">
+    <meta name="author" content="Adam Johnston">
+    <link rel="canonical" href="https://aspartameawareness.org/quiz">
+    <meta name="robots" content="index, follow">
+    <meta property="og:title" content="Aspartame Awareness Quiz">
+    <meta property="og:description" content="Challenge yourself and learn more about aspartame.">
+    <meta property="og:image" content="https://aspartameawareness.org/images/logos/logo-A2.png">
+    <meta property="og:url" content="https://aspartameawareness.org/quiz">
+    <meta property="og:type" content="website">
+    <script src="js/jquery.min.js"></script>
+    <script src="js/quiz.js" defer></script>
+</head>
+<body class="is-preload">
+<script>(function(){var s=localStorage.getItem('darkMode');var m=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='true'||(s===null&&m)){document.body.classList.add('dark-mode');var meta=document.querySelector('meta[name="theme-color"]');if(meta)meta.setAttribute('content','#181818');}})();</script>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <div id="wrapper">
+    <header id="header">
+      <h1><a href="/">Aspartame Awareness<span class="small-org">.org</span></a></h1>
+      <nav class="links">
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="blogs/aspartame">What is Aspartame?</a></li>
+          <li><a href="list-risks">Risks</a></li>
+          <li><a href="blogs/alternatives">Alternatives</a></li>
+          <li><a href="research">Research</a></li>
+          <li><a href="quiz">Quiz</a></li>
+        </ul>
+      </nav>
+    </header>
+    <div id="main">
+      <article class="post">
+        <div class="title">
+          <h2>Test Your Knowledge</h2>
+          <p>Answer the questions below to see how well you know aspartame.</p>
+        </div>
+        <section id="quiz-container"></section>
+        <div id="quiz-result" style="display:none;"></div>
+      </article>
+    </div>
+    <section id="menu">
+      <div>
+        <form class="search">
+          <input type="text" id="searchInput2" name="query" placeholder="Search...">
+          <div id="dropdown2" class="dropdown"></div>
+        </form>
+      </div>
+      <div>
+        <ul class="links" id="sidebar-list"></ul>
+      </div>
+    </section>
+  </div>
+  <script src="js/sidebar-list.js"></script>
+  <script src="js/search-box.js"></script>
+  <script src="js/jquery.min.js"></script>
+  <script src="js/browser.min.js"></script>
+  <script src="js/breakpoints.min.js"></script>
+  <script src="js/util.js"></script>
+  <script src="js/dark-mode.js"></script>
+  <script src="js/main.js"></script>
+  <script src="js/cookie-banner.js"></script>
+  <script src="js/sw-register.js"></script>
+  <script src="/js/includes.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -23,6 +23,7 @@
   <url><loc>https://aspartameawareness.org/research</loc></url>
   <url><loc>https://aspartameawareness.org/service</loc></url>
   <url><loc>https://aspartameawareness.org/support</loc></url>
+  <url><loc>https://aspartameawareness.org/quiz</loc></url>
   <url><loc>https://aspartameawareness.org/offline</loc></url>
   <url><loc>https://aspartameawareness.org/contact</loc></url>
 </urlset>

--- a/sw.js
+++ b/sw.js
@@ -25,6 +25,8 @@ const urlsToCache = [
   '/js/random-author.js',
   '/js/dark-mode.js',
   '/js/search-box.js',
+  '/quiz',
+  '/js/quiz.js',
   "/blogs/adhd",
   "/blogs/alternatives",
   "/blogs/aspartame-side-effects",


### PR DESCRIPTION
## Summary
- add navigation link to Quiz
- include Quiz in footer sitemap
- implement new quiz game page with questions and scoring
- support the quiz via sidebar list, service worker and sitemap

## Testing
- `npx -y htmlhint quiz.html`

------
https://chatgpt.com/codex/tasks/task_e_686dcd517754832991c420b3fb2b67e9