### PR TITLE
Fix header and dark mode on blog pages

### DIFF
--- a/blogs/adhd.html
+++ b/blogs/adhd.html
@@ -219,5 +219,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/blogs/alternatives.html
+++ b/blogs/alternatives.html
@@ -221,5 +221,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/blogs/aspartame-side-effects.html
+++ b/blogs/aspartame-side-effects.html
@@ -220,5 +220,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/blogs/aspartame.html
+++ b/blogs/aspartame.html
@@ -243,5 +243,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/blogs/ban.html
+++ b/blogs/ban.html
@@ -179,5 +179,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/blogs/carcinogenic.html
+++ b/blogs/carcinogenic.html
@@ -217,5 +217,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/blogs/detox.html
+++ b/blogs/detox.html
@@ -214,5 +214,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/blogs/diabetes.html
+++ b/blogs/diabetes.html
@@ -171,5 +171,6 @@
         <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
     </body>
 </html>

--- a/blogs/e951.html
+++ b/blogs/e951.html
@@ -302,5 +302,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/blogs/methanol.html
+++ b/blogs/methanol.html
@@ -209,5 +209,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/blogs/phenylalanine.html
+++ b/blogs/phenylalanine.html
@@ -206,5 +206,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/blogs/understanding.html
+++ b/blogs/understanding.html
@@ -290,5 +290,6 @@
     <script src="../js/main.js"></script>
     <script src="../js/cookie-banner.js"></script>
     <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
 </body>
 </html>

--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -2,7 +2,13 @@
 
 function initDarkMode() {
     const navList = document.querySelector('nav.main ul');
-    if (!navList) return;
+    if (!navList) {
+        // If the navigation hasn't been injected yet wait for the header
+        // to load and then initialise dark mode. Using `{ once: true }`
+        // ensures this handler runs a single time.
+        document.addEventListener('headerLoaded', initDarkMode, { once: true });
+        return;
+    }
 
     const li = document.createElement('li');
     const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- load the global header/footer on each blog post page
- initialize dark mode after the header loads

## Testing
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686f0faeaa4c8329b315b6e58e2e1be7