### PR TITLE
Fix dark mode toggle layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -3506,17 +3506,13 @@ nav.main {
 
                 }
 
-                @media screen and (max-width: 480px) {
-
-                        #header #darkModeToggle {
-                                display: inline-block;
-                                padding-left: 0.75em;
-                                color: inherit;
-                                width: 3em;
-                                text-indent: 3em;
-                        }
-
-                }
+#header #darkModeToggle {
+    display: inline-block;
+    padding-left: 0.75em;
+    color: inherit;
+    width: 3em;
+    text-indent: 3em;
+}
 
 /* Wrapper */
 

--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -14,10 +14,13 @@ function initDarkMode() {
     const a = document.createElement('a');
     a.href = '#';
     a.id = 'darkModeToggle';
-    a.className = 'icon solid fa-moon';
     a.style.cursor = 'pointer';
     a.setAttribute('aria-label', 'Switch to dark mode');
     a.setAttribute('title', 'Switch to dark mode');
+
+    const icon = document.createElement('i');
+    icon.className = 'fa-solid fa-moon';
+    a.appendChild(icon);
 
     // Accessibility label that is visually hidden by the theme's
     // `.icon > .label` rule.
@@ -65,14 +68,14 @@ function initDarkMode() {
 
     function updateIcon() {
         if (document.body.classList.contains('dark-mode')) {
-            a.classList.remove('fa-moon');
-            a.classList.add('fa-sun');
+            icon.classList.remove('fa-moon');
+            icon.classList.add('fa-sun');
             a.setAttribute('aria-label', 'Switch to light mode');
             a.setAttribute('title', 'Switch to light mode');
             if (themeMeta) themeMeta.setAttribute('content', '#181818');
         } else {
-            a.classList.remove('fa-sun');
-            a.classList.add('fa-moon');
+            icon.classList.remove('fa-sun');
+            icon.classList.add('fa-moon');
             a.setAttribute('aria-label', 'Switch to dark mode');
             a.setAttribute('title', 'Switch to dark mode');
             if (themeMeta) themeMeta.setAttribute('content', '#ffffff');


### PR DESCRIPTION
## Summary
- switch dark mode toggle markup to use a `<i>` icon
- ensure toggle is styled on all screen sizes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870efe74ca88329b6537cf3844c6308