### PR TITLE
Enhance SEO tags in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,14 @@
 
     gtag('config', 'G-66V8PFSQ44');
     </script>
-                <title>Aspartame Awareness | Health Risks, Research, and Alternatives</title>
+                <title>Aspartame - Health Risks, Research, and Alternatives | Aspartame Awareness</title>
                 <meta charset="utf-8">
                 <meta name="viewport" content="width=device-width, initial-scale=1">
                 <meta name="theme-color" content="#ffffff">
                 <link rel="stylesheet" href="css/main.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">
-    <meta name="description" content="Aspartame Awareness offers research-based insights on aspartame (E951), its side effects, and safer sweetener alternatives to help you make informed choices.">
+    <meta name="description" content="Aspartame health risks, research updates, and safer sweetener alternatives from Aspartame Awareness to help you make informed choices.">
     <meta name="keywords" content="aspartame, E951, aspartame side effects, health risks, artificial sweeteners, sugar substitute, aspartame detox, aspartame alternatives, aspartame research, aspartame dangers">
     <meta name="author" content="Adam Johnston">
     <link rel="canonical" href="https://aspartameawareness.org/">


### PR DESCRIPTION
## Summary
- tweak homepage title tag to start with "Aspartame"
- emphasize aspartame in meta description

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a56956c408329a3de6124b206838f