### PR TITLE
refactor: centralize random post utility

### DIFF
--- a/blogs/adhd.html
+++ b/blogs/adhd.html
@@ -161,6 +161,7 @@
 	<script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
 	<script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/alternatives.html
+++ b/blogs/alternatives.html
@@ -163,6 +163,7 @@
         <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
         <script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/aspartame-side-effects.html
+++ b/blogs/aspartame-side-effects.html
@@ -162,6 +162,7 @@
     <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
 	<script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/aspartame.html
+++ b/blogs/aspartame.html
@@ -185,6 +185,7 @@
     <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
 	<script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/ban.html
+++ b/blogs/ban.html
@@ -121,6 +121,7 @@
     <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
 	<script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/detox.html
+++ b/blogs/detox.html
@@ -156,6 +156,7 @@
     <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
 	<script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/diabetes.html
+++ b/blogs/diabetes.html
@@ -114,6 +114,7 @@
         <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
         <script defer src="https://static.addtoany.com/menu/page.js"></script>
         <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
         <script src="../js/mini-posts.js"></script><!--small post cards-->
         <script src="../js/random-author.js"></script><!--author name-->
         <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/e951.html
+++ b/blogs/e951.html
@@ -242,6 +242,7 @@
 	<script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
 	<script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/gut-health.html
+++ b/blogs/gut-health.html
@@ -161,6 +161,7 @@
     <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
 	<script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/methanol.html
+++ b/blogs/methanol.html
@@ -151,6 +151,7 @@
 	<script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
 	<script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/phenylalanine.html
+++ b/blogs/phenylalanine.html
@@ -148,6 +148,7 @@
     <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
 	<script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/blogs/understanding.html
+++ b/blogs/understanding.html
@@ -232,6 +232,7 @@
     <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
 	<script defer src="https://static.addtoany.com/menu/page.js"></script>
     <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/post-utils.js"></script><!--post utilities-->
     <script src="../js/mini-posts.js"></script><!--small post cards-->
     <script src="../js/random-author.js"></script><!--author name-->
     <script src="../js/urls-blog.js"></script><!--next button-->

--- a/index.html
+++ b/index.html
@@ -284,6 +284,7 @@
 
 	<!-- Scripts -->
 	<script src="js/sidebar-list.js"></script><!--hamburger menu list-->
+        <script src="js/post-utils.js"></script><!--post utilities-->
 	<script src="js/mini-posts-home.js"></script><!--small post cards-->
 	<script src="js/urls.js"></script><!--next button-->
 	<script src="js/list-posts.js"></script>

--- a/js/list-posts.js
+++ b/js/list-posts.js
@@ -1,10 +1,3 @@
-// Function to get a random set of posts (5 posts in this case)
-function getRandomPosts(posts, numPosts) {
-    // Shuffle the array and return the first `numPosts` elements
-    const shuffled = posts.sort(() => 0.5 - Math.random());
-    return shuffled.slice(0, numPosts);
-}
-
 // Function to load and display posts
 function loadPosts() {
     // Fetch the JSON data

--- a/js/mini-posts-home.js
+++ b/js/mini-posts-home.js
@@ -1,10 +1,3 @@
-// Function to get a random subset of posts
-function getRandomPosts(posts, numPosts) {
-    // Shuffle the array and return the first `numPosts` elements
-    const shuffled = posts.sort(() => 0.5 - Math.random());
-    return shuffled.slice(0, numPosts);
-}
-
 // Function to load and display mini posts
 function loadMiniPosts() {
     console.log("Attempting to load mini posts...");

--- a/js/mini-posts.js
+++ b/js/mini-posts.js
@@ -1,10 +1,3 @@
-// Function to get a random subset of posts
-function getRandomPosts(posts, numPosts) {
-    // Shuffle the array and return the first `numPosts` elements
-    const shuffled = posts.sort(() => 0.5 - Math.random());
-    return shuffled.slice(0, numPosts);
-}
-
 // Function to load and display mini posts
 function loadMiniPosts() {
     // Fetch the JSON data

--- a/js/post-utils.js
+++ b/js/post-utils.js
@@ -1,0 +1,6 @@
+// Utility functions for working with post collections
+// Returns a random subset of the provided posts array
+function getRandomPosts(posts, numPosts) {
+  const shuffled = [...posts].sort(() => 0.5 - Math.random());
+  return shuffled.slice(0, numPosts);
+}

--- a/sw.js
+++ b/sw.js
@@ -19,6 +19,7 @@ const urlsToCache = [
   '/js/browser.min.js',
   '/js/breakpoints.min.js',
   '/js/util.js',
+  '/js/post-utils.js',
   '/js/sidebar-list.js',
   '/js/mini-posts-home.js',
   '/js/list-posts.js',


### PR DESCRIPTION
## Summary
- extract repeated `getRandomPosts` helper into `post-utils.js`
- load shared helper on homepage and blog pages to reduce duplication
- cache utility through service worker for offline support

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c12c623988329bbb8dd87a38eab8f