### PR TITLE
Fix missing header and footer on carcinogenic blog

### DIFF
--- a/blogs/carcinogenic.html
+++ b/blogs/carcinogenic.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- AspartameAwareness.org
     Thanks @ajlkn CCA 3.0 license (html5up.net/license) -->
-<html>
+<html lang="en">
     <head>
 <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-66V8PFSQ44"></script>
@@ -152,3 +152,25 @@
             </section>
         </article>
                      
+    </div><!-- /wrapper -->
+    <div id="footer-placeholder"></div>
+
+    <!-- Scripts -->
+        <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
+        <script defer src="https://static.addtoany.com/menu/page.js"></script>
+    <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/mini-posts.js"></script><!--small post cards-->
+    <script src="../js/random-author.js"></script><!--author name-->
+    <script src="../js/urls-blog.js"></script><!--next button-->
+<script src="../js/search-box.js"></script>
+    <script src="../js/jquery.min.js"></script>
+    <script src="../js/browser.min.js"></script>
+    <script src="../js/breakpoints.min.js"></script>
+    <script src="../js/util.js"></script>
+    <script src="../js/dark-mode.js"></script>
+    <script src="../js/main.js"></script>
+    <script src="../js/cookie-banner.js"></script>
+    <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- close HTML structure on `carcinogenic.html`
- include footer placeholder and script section
- load `dark-mode.js` and other JS to restore navigation and theme toggle

## Testing
- `tidy -errors blogs/carcinogenic.html`

------
https://chatgpt.com/codex/tasks/task_e_688c0207991483298102df97dcdca066