### PR TITLE
Fix navigation, footer, and dark mode on carcinogenic blog page

### DIFF
--- a/blogs/carcinogenic.html
+++ b/blogs/carcinogenic.html
@@ -19,26 +19,26 @@
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/brands.min.css">
 
-		<link rel="apple-touch-icon" sizes="57x57" href="../images/favicon/apple-icon-57x57.png">
-		<link rel="apple-touch-icon" sizes="60x60" href="../images/favicon/apple-icon-60x60.png">
-		<link rel="apple-touch-icon" sizes="72x72" href="../images/favicon/apple-icon-72x72.png">
-		<link rel="apple-touch-icon" sizes="76x76" href="../images/favicon/apple-icon-76x76.png">
-		<link rel="apple-touch-icon" sizes="114x114" href="images/favicon/apple-icon-114x114.png">
-		<link rel="apple-touch-icon" sizes="120x120" href="images/favicon/apple-icon-120x120.png">
-		<link rel="apple-touch-icon" sizes="144x144" href="images/favicon/apple-icon-144x144.png">
-		<link rel="apple-touch-icon" sizes="152x152" href="images/favicon/apple-icon-152x152.png">
-		<link rel="apple-touch-icon" sizes="180x180" href="images/favicon/apple-icon-180x180.png">
-		<link rel="icon" type="image/png" sizes="192x192"  href="images/favicon/android-icon-192x192.png">
-		<link rel="icon" type="image/png" sizes="32x32" href="images/favicon/favicon-32x32.png">
-		<link rel="icon" type="image/png" sizes="96x96" href="images/favicon/favicon-96x96.png">
-		<link rel="icon" type="image/png" sizes="16x16" href="images/favicon/favicon-16x16.png">
-		<link rel="icon" href="images/favicon/favicon.ico" type="image/x-icon">
-		<link rel="shortcut icon" href="images/favicon/favicon.ico" type="image/x-icon">
-		<link rel="manifest" href="images/favicon/manifest.json">
+                <link rel="apple-touch-icon" sizes="57x57" href="/images/favicon/apple-icon-57x57.png">
+                <link rel="apple-touch-icon" sizes="60x60" href="/images/favicon/apple-icon-60x60.png">
+                <link rel="apple-touch-icon" sizes="72x72" href="/images/favicon/apple-icon-72x72.png">
+                <link rel="apple-touch-icon" sizes="76x76" href="/images/favicon/apple-icon-76x76.png">
+                <link rel="apple-touch-icon" sizes="114x114" href="/images/favicon/apple-icon-114x114.png">
+                <link rel="apple-touch-icon" sizes="120x120" href="/images/favicon/apple-icon-120x120.png">
+                <link rel="apple-touch-icon" sizes="144x144" href="/images/favicon/apple-icon-144x144.png">
+                <link rel="apple-touch-icon" sizes="152x152" href="/images/favicon/apple-icon-152x152.png">
+                <link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-icon-180x180.png">
+                <link rel="icon" type="image/png" sizes="192x192"  href="/images/favicon/android-icon-192x192.png">
+                <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
+                <link rel="icon" type="image/png" sizes="96x96" href="/images/favicon/favicon-96x96.png">
+                <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
+                <link rel="icon" href="/images/favicon/favicon.ico" type="image/x-icon">
+                <link rel="shortcut icon" href="/images/favicon/favicon.ico" type="image/x-icon">
+                <link rel="manifest" href="/images/favicon/manifest.json">
 
-		<meta name="msapplication-TileColor" content="#ffffff">
-		<meta name="msapplication-TileImage" content="images/favicon/ms-icon-144x144.png">
-		<meta name="theme-color" content="#ffffff">
+                <meta name="msapplication-TileColor" content="#ffffff">
+                <meta name="msapplication-TileImage" content="/images/favicon/ms-icon-144x144.png">
+                <meta name="theme-color" content="#ffffff">
 
         <meta name="description" content="A detailed exploration of aspartame's carcinogenic risks, with insights from IARC findings and recent studies.">
     <link rel="canonical" href="https://aspartameawareness.org/blogs/carcinogenic">
@@ -88,9 +88,9 @@
                 <h3>Key Studies on Aspartame's Carcinogenic Potential</h3>
                 <p><span class="image left"><img loading="lazy" src="../images/blog/md/vial-md.jpg" alt="lab vials"></span>One of the most notable studies on aspartame's carcinogenic effects was conducted by the Ramazzini Institute<a href="#ref" class="ref" title="Ramazzini Institute">(2)</a> in Italy, which carried out several large-scale rodent studies. These studies found an increased incidence of tumors in rats exposed to aspartame over their lifetime. Specifically, the studies observed a higher rate of lymphomas, leukemias, and other cancers in both male and female rats. Although the methods used by the Ramazzini Institute have been critiqued, the findings raised enough concerns to warrant a reevaluation of aspartame by various health bodies.</p>
 
-                <p>Another significant study published in the <i>American Journal of Industrial Medicine</span><a href="#ref" class="ref" title="American Journal of Industrial Medicine">(3)</a> pointed out that earlier studies conducted by G. D. Searle, the company that first sought market approval for aspartame, were insufficient. According to the commentary, more recent carcinogenicity studies involving rats and mice showed consistent evidence of aspartame's potential to interfere with cancer-related cellular pathways, promoting the likelihood of tumors in these animals.</p>
+                <p>Another significant study published in the <i>American Journal of Industrial Medicine</i><a href="#ref" class="ref" title="American Journal of Industrial Medicine">(3)</a> pointed out that earlier studies conducted by G. D. Searle, the company that first sought market approval for aspartame, were insufficient. According to the commentary, more recent carcinogenicity studies involving rats and mice showed consistent evidence of aspartame's potential to interfere with cancer-related cellular pathways, promoting the likelihood of tumors in these animals.</p>
 
-                <p>A more recent review published in <i>Scientific Reports</span><a href="#ref" class="ref" title="Scientific Reports">(4)</a> in 2024 applied advanced toxicology methods, such as network toxicology and molecular docking, to evaluate aspartame's potential effects at the molecular level. The findings suggested that aspartame could interact with cancer-related proteins, increasing the chances of cellular carcinogenesis by disrupting normal biomolecular functions.</p>
+                <p>A more recent review published in <i>Scientific Reports</i><a href="#ref" class="ref" title="Scientific Reports">(4)</a> in 2024 applied advanced toxicology methods, such as network toxicology and molecular docking, to evaluate aspartame's potential effects at the molecular level. The findings suggested that aspartame could interact with cancer-related proteins, increasing the chances of cellular carcinogenesis by disrupting normal biomolecular functions.</p>
 
                 <h3>Conflicting Opinions: The FDA and EFSA Standpoints</h3>
                 <p><span class="image right"><img loading="lazy" src="../images/scan.jpg" alt="brain scan image"></span>Despite the reclassification by IARC, regulatory bodies like the Food and Drug Administration (FDA) and the European Food Safety Authority (EFSA)<a href="#ref" class="ref" title="FDA and EFSA Statements on Aspartame Safety.">(5)</a> have maintained that aspartame is safe for consumption within the established daily limits. The FDA, in particular, has stated that the studies do not provide sufficient evidence to link aspartame conclusively to cancer. They argue that the doses tested in animal studies far exceed what a human would typically consume, and thus, the results might not be applicable to everyday consumption.<a href="#ref" class="ref" title="FDA and EFSA">(6)</a></p>
@@ -135,7 +135,7 @@
                     </ul>
                 </footer>
             </article>
-        </div>
+        </div><!-- /main -->
 
         <!-- Pagination -->
         <ul class="actions pagination">
@@ -151,4 +151,25 @@
                 </div>
             </section>
         </article>
-                     
+    </div><!-- /wrapper -->
+    <div id="footer-placeholder"></div>
+
+    <!-- Scripts -->
+        <script> var a2a_config = a2a_config || {}; a2a_config.num_services = 6;</script><!--add to any-->
+        <script defer src="https://static.addtoany.com/menu/page.js"></script>
+    <script src="../js/sidebar-list-blog.js"></script><!--hamburger menu list-->
+    <script src="../js/mini-posts.js"></script><!--small post cards-->
+    <script src="../js/random-author.js"></script><!--author name-->
+    <script src="../js/urls-blog.js"></script><!--next button-->
+    <script src="../js/search-box.js"></script>
+    <script src="../js/jquery.min.js"></script>
+    <script src="../js/browser.min.js"></script>
+    <script src="../js/breakpoints.min.js"></script>
+    <script src="../js/util.js"></script>
+    <script src="../js/dark-mode.js"></script>
+    <script src="../js/main.js"></script>
+    <script src="../js/cookie-banner.js"></script>
+    <script src="../js/sw-register.js"></script>
+    <script src="../js/includes.js"></script>
+</body>
+</html>

--- a/quiz.html
+++ b/quiz.html
@@ -56,6 +56,7 @@
     </div>
     <!-- Menu will be loaded from header.html -->
   </div>
+  <div id="footer-placeholder"></div>
   <script src="js/sidebar-list.js"></script>
   <script src="js/search-box.js"></script>
   <script src="js/jquery.min.js"></script>

--- a/research.html
+++ b/research.html
@@ -166,7 +166,7 @@
                     </ul>
                 </footer>
             </article>
-        </div>
+        </div><!-- /main -->
 
         <!-- Pagination -->
         <ul class="actions pagination">
@@ -174,7 +174,8 @@
             <li><a href="/" aria-label="Home" class="button large previous"><span aria-hidden="true" class="fas fa-home"></span> Home</a></li>
         </ul>
 
-	</div><!-- /main -->
+    </div><!-- /wrapper -->
+    <div id="footer-placeholder"></div>
 
     <!-- Scripts -->
     <script src="js/sidebar-list.js"></script>


### PR DESCRIPTION
## Summary
- Correct favicon paths and restore scripts on the "Is Aspartame Carcinogenic" blog page so navigation, dark mode, and "More posts" work again.
- Add missing footer placeholders and close wrappers properly on `research.html` and `quiz.html`.

## Testing
- `npx --yes htmlhint blogs/carcinogenic.html research.html quiz.html`

------
https://chatgpt.com/codex/tasks/task_e_688eb02c6a248329a30fba2495a4abb3