### PR TITLE
refactor: modular component loading

### DIFF
--- a/js/includes.js
+++ b/js/includes.js
@@ -1,27 +1,25 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const footer = document.getElementById('footer-placeholder');
-  if (footer) {
-    fetch('/components/footer.html')
-      .then(resp => resp.text())
-      .then(html => {
-        footer.innerHTML = html;
-      })
-      .catch(err => console.error('Failed to load footer:', err));
-  }
+  const loadComponent = (id, url, callback) => {
+    const el = document.getElementById(id);
+    if (!el) {
+      if (callback) callback();
+      return;
+    }
 
-  const header = document.getElementById('header-placeholder');
-  if (header) {
-    fetch('/components/header.html')
+    fetch(url)
       .then(resp => resp.text())
       .then(html => {
-        header.innerHTML = html;
-        document.dispatchEvent(new Event('headerLoaded'));
+        el.innerHTML = html;
+        if (callback) callback();
       })
       .catch(err => {
-        console.error('Failed to load header:', err);
-        document.dispatchEvent(new Event('headerLoaded'));
+        console.error(`Failed to load ${id}:`, err);
+        if (callback) callback();
       });
-  } else {
-    document.dispatchEvent(new Event('headerLoaded'));
-  }
+  };
+
+  loadComponent('footer-placeholder', '/components/footer.html');
+  loadComponent('header-placeholder', '/components/header.html', () =>
+    document.dispatchEvent(new Event('headerLoaded'))
+  );
 });


### PR DESCRIPTION
## Summary
- reduce duplicate fetch logic for header and footer
- centralize component fetching in reusable `loadComponent` helper

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/includes.js`


------
https://chatgpt.com/codex/tasks/task_e_689210570c5c832984391e5747cebde8