### PR TITLE
Add initial component catalog and stubs

### DIFF
--- a/site/COMPONENTS.md
+++ b/site/COMPONENTS.md
@@ -1,0 +1,77 @@
+# Component Catalog
+
+## Callout
+- **Props**
+  - `type`: "note" | "tip" | "warning" | "danger"
+  - `children`: MDX content
+- **Example**
+  ```mdx
+  <Callout type="warning">
+    Aspartame is unsafe for individuals with PKU.
+  </Callout>
+  ```
+- **Appears in**
+  - content-mdx/posts/ban.mdx (blockquote quote)
+
+## Figure
+- **Props**
+  - `src`: string
+  - `alt`: string
+  - `caption?`: string
+  - `credit?`: string
+- **Example**
+  ```mdx
+  <Figure src="../images/supplements.jpg" alt="Detox supplements" caption="Detox supports" credit="Healthline" />
+  ```
+- **Appears in**
+  - content-mdx/posts/detox.mdx
+  - content-mdx/posts/carcinogenic.mdx
+  - content-mdx/pages/index.mdx
+
+## Badge
+- **Props**
+  - `tone`: "yellow" | "orange" | "red"
+  - `children`: string
+- **Example**
+  ```mdx
+  <Badge tone="red">PKU Warning</Badge>
+  ```
+- **Appears in**
+  - _No current usage_
+
+## InlineDef
+- **Props**
+  - `term`: string
+  - `def`: string
+- **Example**
+  ```mdx
+  <InlineDef term="PKU" def="Phenylketonuria" />
+  ```
+- **Appears in**
+  - _No current usage_
+
+## Ref
+- **Props**
+  - `id`: string
+  - `children`: string
+- **Example**
+  ```mdx
+  <Ref id="1">FDA (2024)</Ref>
+  ```
+- **Appears in**
+  - content-mdx/posts/adhd.mdx
+  - content-mdx/posts/gut-health.mdx
+  - content-mdx/posts/detox.mdx
+  - content-mdx/posts/alternatives.mdx
+  - content-mdx/posts/aspartame.mdx
+  - content-mdx/posts/carcinogenic.mdx
+
+### Additional Patterns
+
+- **Table**
+  - Found in: content-mdx/posts/understanding.mdx
+  - Suggest `<Table caption>{children}</Table>` component
+- **Quiz Placeholder**
+  - Found in: content-mdx/pages/quiz.mdx
+  - Suggest `<Quiz id />` component
+

--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -1,0 +1,3 @@
+export default function Badge({ tone = 'yellow', children }) {
+  return <span>[{tone}] {children}</span>;
+}

--- a/src/components/Callout.jsx
+++ b/src/components/Callout.jsx
@@ -1,0 +1,3 @@
+export default function Callout({ type = 'note', children }) {
+  return <div>[{type}] {children}</div>;
+}

--- a/src/components/Figure.jsx
+++ b/src/components/Figure.jsx
@@ -1,0 +1,11 @@
+export default function Figure({ src, alt = '', caption, credit }) {
+  if (!src) {
+    return <figure>{caption}{credit ? ` (${credit})` : ''}</figure>;
+  }
+  return (
+    <figure>
+      <img src={src} alt={alt} />
+      {(caption || credit) && <figcaption>{caption}{credit ? ` — ${credit}` : ''}</figcaption>}
+    </figure>
+  );
+}

--- a/src/components/InlineDef.jsx
+++ b/src/components/InlineDef.jsx
@@ -1,0 +1,3 @@
+export default function InlineDef({ term, def }) {
+  return <span>{term} ({def})</span>;
+}

--- a/src/components/Ref.jsx
+++ b/src/components/Ref.jsx
@@ -1,0 +1,3 @@
+export default function Ref({ id, children }) {
+  return <sup id={id}>{children}</sup>;
+}


### PR DESCRIPTION
## Summary
- catalog existing component needs and examples in `site/COMPONENTS.md`
- add text-only stubs for Callout, Figure, Badge, InlineDef, and Ref components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1780151883299b8bd95381b48505