### PR TITLE
Add staged binary file guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This is the official repository for the Aspartame Awareness website, aimed at providing information and raising awareness about the effects of aspartame. https://aspartameawareness.org",
   "main": "sw.js",
   "scripts": {
-    "test": "echo \"No tests specified\""
+    "test": "echo \"No tests specified\"",
+    "check:nobin": "node tools/no-binaries-check.mjs"
   },
   "keywords": [],
   "author": "",

--- a/site/tools/no-binaries-check.mjs
+++ b/site/tools/no-binaries-check.mjs
@@ -1,0 +1,14 @@
+import { execSync } from 'node:child_process';
+
+const binaryPattern = /\.(png|jpe?g|gif|webp|svg|ico|ttf|otf|woff2?|eot|mp4|mov|pdf)$/i;
+
+const output = execSync('git diff --cached --name-only', { encoding: 'utf8' });
+const files = output.split(/\r?\n/).filter(Boolean);
+const offenders = files.filter((f) => binaryPattern.test(f));
+
+if (offenders.length) {
+  console.error('Binary files detected in commit:');
+  offenders.forEach((file) => console.error(` - ${file}`));
+  console.error('\nUpload these manually via GitHub after merge.');
+  process.exit(1);
+}

--- a/tools/no-binaries-check.mjs
+++ b/tools/no-binaries-check.mjs
@@ -1,0 +1,1 @@
+import '../site/tools/no-binaries-check.mjs';


### PR DESCRIPTION
## Summary
- prevent committing binary assets by checking staged files for common binary extensions
- add `npm run check:nobin` for running the binary file guard before pushing

## Testing
- `npm run check:nobin`


------
https://chatgpt.com/codex/tasks/task_e_68c6b741a788832981fa381760996fc3